### PR TITLE
Support optional biometrics on iOS platform.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_local_authentication/flutter_local_authentication.dart';
@@ -44,6 +45,10 @@ class _HomeWidgetState extends State<HomeWidget> {
         cancelButtonTitle: "cancel"
     );
     _flutterLocalAuthenticationPlugin.setLocalizationModel(localization);
+
+    if (Platform.isIOS) {
+      _flutterLocalAuthenticationPlugin.setBiometricsRequired(false);
+    }
   }
 
   Future<void> checkSupport() async {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ description: "Demonstrates how to use the flutter_local_authentication plugin."
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: '>=3.1.3 <4.0.0'
+  sdk: '>=3.1.0 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/ios/Classes/PluginMethod.swift
+++ b/ios/Classes/PluginMethod.swift
@@ -15,6 +15,7 @@ enum PluginMethod {
     case setTouchIDAuthenticationAllowableReuseDuration(duration: Double)
     case getTouchIDAuthenticationAllowableReuseDuration
     case setLocalizationModel(model: LocalizationModel?)
+    case setBiometricsRequired(biometricsRequired: Bool)
 
     static func from(_ call: FlutterMethodCall) -> PluginMethod? {
         switch call.method {
@@ -29,6 +30,14 @@ enum PluginMethod {
         case "setLocalizationModel":
             let model = LocalizationModel.from(call.arguments as? [String: Any])
             return .setLocalizationModel(model: model)
+        case "setBiometricsRequired":
+            if 
+                let arguments = call.arguments as? [String: Any],
+                let biometricsRequired : Bool = arguments["biometricsRequired"] as? Bool {
+                return .setBiometricsRequired(biometricsRequired: biometricsRequired)
+            } else {
+                return nil
+            }
         default:
             return nil
         }

--- a/lib/flutter_local_authentication.dart
+++ b/lib/flutter_local_authentication.dart
@@ -184,4 +184,12 @@ class FlutterLocalAuthentication {
       await FlutterLocalAuthenticationPlatform.instance.setLocalizationModel(localizationModel.toJson());
     }
   }
+
+  Future<void> setBiometricsRequired(
+      bool biometricsRequired) async {
+    if (Platform.isIOS) {
+      return await FlutterLocalAuthenticationPlatform.instance
+          .setBiometricsRequired(biometricsRequired);
+    }
+  }
 }

--- a/lib/flutter_local_authentication_method_channel.dart
+++ b/lib/flutter_local_authentication_method_channel.dart
@@ -102,4 +102,10 @@ class MethodChannelFlutterLocalAuthentication
       Map<String, dynamic> localizationModel) async {
     await methodChannel.invokeMethod('setLocalizationModel', localizationModel);
   }
+
+  @override
+  Future<void> setBiometricsRequired(
+      bool biometricsRequired) async {
+    await methodChannel.invokeMethod('setBiometricsRequired', {'biometricsRequired': biometricsRequired});
+  }
 }

--- a/lib/flutter_local_authentication_platform_interface.dart
+++ b/lib/flutter_local_authentication_platform_interface.dart
@@ -74,4 +74,11 @@ abstract class FlutterLocalAuthenticationPlatform extends PlatformInterface {
     throw UnimplementedError(
         'setLocalizationModel() has not been implemented.');
   }
+  
+  /// Sets whether biometrics are required (iOS only).
+  Future<void> setBiometricsRequired(
+      bool biometricsRequired) {
+    throw UnimplementedError(
+        'setBiometricsRequired() has not been implemented.');
+  }
 }


### PR DESCRIPTION
So that user's without biometrics enrolled can authenticate using a PIN.

Adds the `setBiometricsRequired()` iOS specific-method, users can call `plugin.setBiometricsRequired(false)` to override the default behavior (biometrics required) and support PIN authentication on iOS.